### PR TITLE
#165179990 Delete account route

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "lite bank app",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --require @babel/register ./server/test/*.spec.js --exit",
+    "test": "mocha --require @babel/register ./server/test/*.spec.js --exit --watch",
     "test-watch": "nodemon --exec \"npm test\"",
     "start": "node dist/server",
-    "build": "babel server --out-dir dist",
-    "devstart": "nodemon --exec babel-node server/server.js"
+    "build": "babel server --out-dir dist"
   },
   "repository": {
     "type": "git",

--- a/server/controllers/accounts.js
+++ b/server/controllers/accounts.js
@@ -3,6 +3,15 @@ import helper from '../helpers/account';
 import accounts from '../models/accounts';
 
 class AccountController {
+  /**
+   *handles the request to add a new account
+   *
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @returns new account details as a response
+   * @memberof AccountController
+   */
   static postAccount(req, res) {
     const { id, type } = req.body;
 
@@ -26,6 +35,15 @@ class AccountController {
     });
   }
 
+  /**
+   *handles the request to add toggle accounts status
+   *
+   * @static patchAccount
+   * @param {object} req
+   * @param {object} res
+   * @returns account number and accounts new status as a response
+   * @memberof AccountController
+   */
   static patchAccount(req, res) {
     const reqAccountNumber = parseInt(req.params.accountNumber, 10);
 
@@ -41,6 +59,17 @@ class AccountController {
         accountNumber,
         status,
       },
+    });
+  }
+
+  static deleteAccount(req, res) {
+    const reqAccountNumber = parseInt(req.params.accountNumber, 10);
+
+    helper.deleteAccount(reqAccountNumber);
+
+    return res.status(200).json({
+      status: 200,
+      message: 'Account successfully deleted',
     });
   }
 }

--- a/server/helpers/account.js
+++ b/server/helpers/account.js
@@ -55,6 +55,19 @@ class AccountHelper {
 
     targetAccount.status = targetAccount.status === 'active' ? 'dormant' : 'active';
   }
+
+  /**
+   *helps delete an account with given account number from accounts record
+   *
+   * @static deleteAccount
+   * @param {object} accountNumber
+   * @memberof AccountHelper
+   */
+  static deleteAccount(accountNumber) {
+    const accountsIndex = accounts.findIndex(account => account.accountNumber === accountNumber);
+
+    accounts.splice(accountsIndex, 1);
+  }
 }
 
 export default AccountHelper;

--- a/server/middleware/validate/account.js
+++ b/server/middleware/validate/account.js
@@ -50,7 +50,7 @@ class ValidateAccount {
    * @returns error 404 if specified account number does not exist
    * @memberof ValidateAccount
    */
-  static patchAccount(req, res, next) {
+  static accountNumber(req, res, next) {
     const reqAccountNumber = parseInt(req.params.accountNumber, 10);
 
     const accountDetails = accounts.find(account => account.accountNumber === reqAccountNumber);

--- a/server/routes/accounts.js
+++ b/server/routes/accounts.js
@@ -6,6 +6,7 @@ import accountValidation from '../middleware/validate/account';
 const router = express.Router();
 
 router.post('/', accountValidation.postAccount, accountController.postAccount);
-router.patch('/:accountNumber', accountValidation.patchAccount, accountController.patchAccount);
+router.patch('/:accountNumber', accountValidation.accountNumber, accountController.patchAccount);
+router.delete('/:accountNumber', accountValidation.accountNumber, accountController.deleteAccount);
 
 export default router;

--- a/server/test/accounts.spec.js
+++ b/server/test/accounts.spec.js
@@ -69,7 +69,7 @@ describe('POST /api/v1/accounts', () => {
   });
 });
 
-describe('PATCH /api/v1/accounts/:accountNumber', () => {
+describe('account status toggle', () => {
   it("should toggle specified account number's from active to dormant", (done) => {
     request(app)
       .patch('/api/v1/accounts/2984756340')
@@ -93,6 +93,28 @@ describe('PATCH /api/v1/accounts/:accountNumber', () => {
   it('should flag that the specified account number does not exist', (done) => {
     request(app)
       .patch('/api/v1/accounts/12121212123984738471481')
+      .expect(404)
+      .expect((res) => {
+        expect(res.body).toIncludeKey('error');
+      })
+      .end(done);
+  });
+});
+
+describe('DELETE account route', () => {
+  it('should delete an account with specified account number', (done) => {
+    request(app)
+      .delete('/api/v1/accounts/1212334342')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.message).toEqual('Account successfully deleted');
+      })
+      .end(done);
+  });
+
+  it('should flag for wrong account number', (done) => {
+    request(app)
+      .delete('/api/v1/accounts/12122212222321223')
       .expect(404)
       .expect((res) => {
         expect(res.body).toIncludeKey('error');


### PR DESCRIPTION
#### What does this PR do?
adds a delete account route to the api

#### Description of Task to be completed?
- adds DELETE api/v1/accounts/:accountNumber endpoint

#### How should this be manually tested?
- clone this repo
- cd into the root directory and run npm install
- run npm start to kick off the server
- copy an account number from the account.js file in the models directory
- make a delete request to the endpoint replacing ':accountNumber' with the copied account number
- should return a message indicating success

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
[#165179990](https://www.pivotaltracker.com/story/show/165179990)

#### Screenshots (if appropriate)
NA

#### Questions:
NA