### PR TITLE
#165331923 heroku postbuild hook for heroku build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "test": "nyc mocha --require @babel/register ./server/test/*.spec.js --exit",
     "test-watch": "nodemon --exec \"npm test\"",
-    "start": "npm run build && node dist/server",
+    "start": "node dist/server",
     "build": "babel server --out-dir dist",
     "devstart": "nodemon --exec babel-node server/server.js",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "heroku-postbuild": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### What does this PR do?
It resolves conflict with hosting server on Heroku

#### Description of Task to be completed?
the start script runs the build script each time it is used, and this causes the app to crash as the dev dependencies have been pruned, which means no access to babel module

#### How should this be manually tested?
when you navigate to the package.json of this file, it should have heroku-postbuild script defined and it runs the build script

#### Any background context you want to provide?
Heroku hosted app is crashing then this resolved the issue

#### What are the relevant pivotal tracker stories?
[#165331923](https://www.pivotaltracker.com/story/show/165331923)

#### Screenshots (if appropriate)
NA

#### Questions:
NA
